### PR TITLE
Fix self reference in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-leaflet": "^4.2.1",
-        "tratokml-web": "file:"
+        "react-leaflet": "^4.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -4084,10 +4083,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tratokml-web": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/trim-repeated": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-leaflet": "^4.2.1",
-    "tratokml-web": "file:"
+    "react-leaflet": "^4.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",


### PR DESCRIPTION
## Summary
- remove invalid self dependency from package.json and lockfile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*